### PR TITLE
docs: add exploit module page

### DIFF
--- a/docs/docs/modules/exploit.md
+++ b/docs/docs/modules/exploit.md
@@ -1,0 +1,112 @@
+---
+sidebar_position: 8.5
+---
+
+# Exploit command
+
+The `exploit` command attempts exploitation of known framework CVEs against a live target to
+discover new attack surface — for example, bypassing a Next.js middleware auth check reveals
+admin-only JS chunks a normal crawl would never see. This is active exploitation, not passive
+detection like `analyze`: only run it against targets you're authorized to test.
+
+## Usage
+
+```bash
+js-recon exploit -u <url> --cve <CVE-ID> [options]
+js-recon exploit --list-cve
+```
+
+## Options
+
+| Option              | Alias | Description                                                        | Default               | Required |
+| ------------------- | ----- | -------------------------------------------------------------------- | ---------------------- | -------- |
+| `--url <url>`       | `-u`  | Target URL                                                          |                        | Yes\*    |
+| `--cve <id>`        |       | CVE ID to exploit (e.g. `CVE-2025-29927`)                          |                        | Yes\*    |
+| `--list-cve`        |       | List all supported CVEs grouped by framework and exit               | `false`                | No       |
+| `--exec-cmd <cmd>`  |       | Command to execute for RCE-class CVE proof (use a read-only command) | `id`                   | No       |
+| `--output <file>`   | `-o`  | Output JSON file for exploit findings                               | `exploit.json`         | No       |
+| `--engine-output <file>` |  | Output JSON file in report-compatible `EngineOutput` format         | `exploit-engine.json`  | No       |
+| `--proxy-config <file>` |   | Proxy config file (generated via the `proxy` module)                | `.proxy_config.json`   | No       |
+| `--ignore-proxy-env`|       | Skip `JS_RECON_*` proxy environment variables during resolution     | `false`                | No       |
+| `--timeout <ms>`    |       | Request timeout in milliseconds                                     | `30000`                | No       |
+| `--insecure`        | `-k`  | Disable SSL certificate verification                                | `false`                | No       |
+
+\* `--list-cve` exits before `--url`/`--cve` are required.
+
+## Supported CVEs
+
+Run `js-recon exploit --list-cve` for the full, always-current list. As of this writing:
+
+| CVE | Framework | Class | Mechanism |
+| --- | --- | --- | --- |
+| `CVE-2025-29927` | Next.js | Auth bypass | `x-middleware-subrequest` header repeated 5x skips middleware entirely |
+| `CVE-2026-64645` | Next.js | SSRF | Dynamic `rewrites()` destination hostname reflects an internal service's response |
+| `CVE-2025-30208` | Vite | Path traversal | Trailing double `?` on `/@fs/` requests bypasses `server.fs.deny` |
+| `CVE-2026-39363` | Vite | Path traversal (WebSocket) | `vite-hmr` WebSocket RPC's `fetchModule` bypasses HTTP-only `fs.deny` |
+| `CVE-2026-71320` | Nuxt | RCE | Server Island template injection → sandbox escape → `child_process` |
+| `CVE-2026-71315` / `CVE-2026-53721` | Nuxt | Auth bypass | Route-rule key casing mismatch skips `appMiddleware` |
+| `CVE-2026-68945` | Angular | Cache poisoning | `HttpTransferCache` key collision between repeated and comma-joined query params |
+| `CVE-2025-55182` | React (RSC) | RCE | Flight reply deserializer prototype-pollution gadget chain, "React2Shell" |
+
+## Examples
+
+### Listing supported CVEs
+
+```bash
+js-recon exploit --list-cve
+```
+
+### Attempting a specific CVE
+
+```bash
+js-recon exploit -u https://example.com/admin --cve CVE-2025-29927
+```
+
+### RCE-class CVE with a custom (still read-only) proof command
+
+```bash
+js-recon exploit -u https://example.com --cve CVE-2026-71320 --exec-cmd "id"
+```
+
+> [!CAUTION]
+> `CVE-2026-71320` and `CVE-2025-55182` are RCE-class — their proof executes `--exec-cmd` on the
+> target server. Only run these against systems you are explicitly authorized to test, and prefer
+> a read-only command (the default, `id`) unless you have a specific reason to run something else.
+
+### Feeding results into a report
+
+```bash
+js-recon exploit -u https://example.com --cve CVE-2025-29927 --engine-output exploit-engine.json
+js-recon report -d output/example.com --exploit-json exploit-engine.json
+```
+
+## Output format
+
+### `exploit.json` (default `-o` output)
+
+A JSON array of one finding per invocation:
+
+```json
+[
+    {
+        "cveId": "CVE-2025-29927",
+        "commonName": "Next.js middleware authorization bypass",
+        "framework": "next",
+        "target": "https://example.com/admin",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "vulnerable": true,
+        "evidence": "Middleware bypassed using x-middleware-subrequest id=\"middleware\" (baseline status 307 -> payload status 200).",
+        "discoveredUrls": ["https://example.com/_next/static/chunks/app/admin/page-abc123.js"]
+    }
+]
+```
+
+`discoveredUrls` — when non-empty — is new attack surface the exploit revealed; feed it into a
+follow-up `lazyload`/`run` pass for further recon.
+
+### `exploit-engine.json` (`--engine-output`)
+
+Same `EngineOutput` shape `analyze.json` uses (see [Analyze command](./analyze.md#output-format)),
+so `report --exploit-json` can render exploit findings in the existing dashboard with no extra
+setup. `ruleType` is always `"exploit"`; `severity` is always `"high"` (the schema's ceiling — RCE
+findings don't get a separate "critical" tier).


### PR DESCRIPTION
## Summary

Companion PR for `js-recon/js-recon#154` (the `exploit` module, `js-recon-internal-docs#152`).
Adds `docs/docs/modules/exploit.md`: flags, the 8 supported CVEs, output formats, and
`report --exploit-json` integration. RCE-class CVEs get an explicit authorization warning.