### PR TITLE
Add JS Recon Scan workflow for PR CI

### DIFF
--- a/.github/workflows/js-recon-scan.yml
+++ b/.github/workflows/js-recon-scan.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: JS Recon
         id: jsrecon
-        uses: js-recon/js-recon-action@d51c71a8cd667d016a099c9ef2e35c8b36d95c59 # v1.0.3
+        uses: js-recon/js-recon-action@349280372829efdf59fbb5386ee6f6809d0a306a # TEMP: fix/puppeteer-chrome-version-mismatch, revert to v1.0.3 tag once js-recon-action#4 merges/releases
         with:
           url: http://localhost:3000
           start-cmd: npm run serve

--- a/.github/workflows/js-recon-scan.yml
+++ b/.github/workflows/js-recon-scan.yml
@@ -1,0 +1,40 @@
+name: JS Recon Scan
+
+on:
+  pull_request:
+    branches: [stage, main]
+  workflow_dispatch: null
+
+permissions:
+  contents: read
+
+jobs:
+  js-recon-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: JS Recon
+        id: jsrecon
+        uses: js-recon/js-recon-action@v1
+        with:
+          url: http://localhost:3000
+          start-cmd: npm run serve
+          working-directory: .
+          version: latest
+          break-on-map-files: true
+          break-on-vulnerabilities: true
+          vulnerability-severity: medium
+
+      - name: Upload JS Recon output
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: js-recon-output
+          path: ${{ steps.jsrecon.outputs.output-path }}

--- a/.github/workflows/js-recon-scan.yml
+++ b/.github/workflows/js-recon-scan.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: JS Recon
         id: jsrecon
-        uses: js-recon/js-recon-action@d51c71a8cd667d016a099c9ef2e35c8b36d95c59 # v1.0.3
+        uses: js-recon/js-recon-action@2811c10ddac88e3929113dc9ccaf41d080e879ef # v1.0.4
         with:
           url: http://localhost:3000
           start-cmd: npm run serve

--- a/.github/workflows/js-recon-scan.yml
+++ b/.github/workflows/js-recon-scan.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: JS Recon
         id: jsrecon
-        uses: js-recon/js-recon-action@v1
+        uses: js-recon/js-recon-action@d51c71a8cd667d016a099c9ef2e35c8b36d95c59 # v1.0.3
         with:
           url: http://localhost:3000
           start-cmd: npm run serve
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload JS Recon output
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: js-recon-output
           path: ${{ steps.jsrecon.outputs.output-path }}

--- a/.github/workflows/js-recon-scan.yml
+++ b/.github/workflows/js-recon-scan.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: JS Recon
         id: jsrecon
-        uses: js-recon/js-recon-action@349280372829efdf59fbb5386ee6f6809d0a306a # TEMP: fix/puppeteer-chrome-version-mismatch, revert to v1.0.3 tag once js-recon-action#4 merges/releases
+        uses: js-recon/js-recon-action@d51c71a8cd667d016a099c9ef2e35c8b36d95c59 # v1.0.3
         with:
           url: http://localhost:3000
           start-cmd: npm run serve


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/js-recon-scan.yml`, dogfooding `js-recon-action` against this docs site as a PR check
- Builds and serves the Docusaurus site, then runs the action with `break-on-map-files: true`, `break-on-vulnerabilities: true`, `vulnerability-severity: medium`, `version: latest`
- On failure, uploads the JS Recon output (`analyze.json`, `report.html`, etc.) as a build artifact for inspection

Closes js-recon/js-recon-internal-docs#170

## Test plan
- [ ] Confirm the `JS Recon Scan` job runs on this PR and completes (pass or a real, fixable finding)
- [ ] If it fails on a real finding, fix it in this docs repo and re-run
- [ ] Once green, mark `JS Recon Scan` as a required status check on `stage` and `main` branch protection