### PR TITLE
Add rule remediation lookup page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .vercel
+
+# Playwright
+/test-results
+/playwright-report

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -83,6 +83,10 @@ const config: Config = {
                     label: "Labs",
                 },
                 {
+                    href: "/remediation",
+                    label: "Remediation",
+                },
+                {
                     href: "/contributing",
                     label: "Contributing",
                 },

--- a/e2e/remediation.spec.ts
+++ b/e2e/remediation.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+
+const REMEDIATION_URL =
+    "https://raw.githubusercontent.com/js-recon/js-recon-rules/main/remediation.json";
+
+const MOCK_REMEDIATION = {
+    detect_hardcoded_secrets:
+        "Revoke and rotate the exposed secret immediately, then remove it from the bundle.",
+};
+
+test.beforeEach(async ({ page }) => {
+    await page.route(REMEDIATION_URL, (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: "application/json",
+            body: JSON.stringify(MOCK_REMEDIATION),
+        }),
+    );
+});
+
+test("shows remediation text for a known rule ID", async ({ page }) => {
+    await page.goto("/remediation");
+    await page
+        .getByRole("textbox", { name: "Rule ID" })
+        .fill("detect_hardcoded_secrets");
+    await expect(
+        page.getByRole("heading", { name: "detect_hardcoded_secrets" }),
+    ).toBeVisible();
+    await expect(
+        page.getByText("Revoke and rotate the exposed secret immediately"),
+    ).toBeVisible();
+});
+
+test("shows the generic fallback for an unknown rule ID", async ({ page }) => {
+    await page.goto("/remediation");
+    await page
+        .getByRole("textbox", { name: "Rule ID" })
+        .fill("this_id_does_not_exist");
+    await expect(
+        page.getByRole("heading", { name: "Not found" }),
+    ).toBeVisible();
+    await expect(
+        page.getByText("No specific remediation found for this rule ID"),
+    ).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "@docusaurus/module-type-aliases": "3.8.1",
                 "@docusaurus/tsconfig": "3.8.1",
                 "@docusaurus/types": "3.8.1",
+                "@playwright/test": "^1.62.1",
                 "typescript": "~5.6.2"
             },
             "engines": {
@@ -4036,6 +4037,22 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+            "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.62.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/@pnpm/config.env-replace": {
@@ -12874,6 +12891,53 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+            "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.62.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+            "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/playwright/node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "serve": "docusaurus serve",
         "write-translations": "docusaurus write-translations",
         "write-heading-ids": "docusaurus write-heading-ids",
-        "typecheck": "tsc"
+        "typecheck": "tsc",
+        "test:e2e": "playwright test"
     },
     "dependencies": {
         "@docusaurus/core": "3.8.1",
@@ -28,6 +29,7 @@
         "@docusaurus/module-type-aliases": "3.8.1",
         "@docusaurus/tsconfig": "3.8.1",
         "@docusaurus/types": "3.8.1",
+        "@playwright/test": "^1.62.1",
         "typescript": "~5.6.2"
     },
     "browserslist": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+    testDir: "./e2e",
+    fullyParallel: true,
+    retries: 0,
+    use: {
+        baseURL: "http://localhost:3211",
+    },
+    projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+    webServer: {
+        command: "npm run start -- --port 3211 --no-open",
+        url: "http://localhost:3211",
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+    },
+});

--- a/src/pages/remediation.tsx
+++ b/src/pages/remediation.tsx
@@ -1,0 +1,124 @@
+import React, { ReactNode, useEffect, useState } from "react";
+import Layout from "@theme/Layout";
+import Heading from "@theme/Heading";
+import clsx from "clsx";
+import styles from "./index.module.css";
+
+const REMEDIATION_URL =
+    "https://raw.githubusercontent.com/js-recon/js-recon-rules/main/remediation.json";
+
+type RemediationMap = Record<string, string>;
+
+function useRemediationMap() {
+    const [map, setMap] = useState<RemediationMap | null>(null);
+    const [error, setError] = useState(false);
+
+    useEffect(() => {
+        fetch(REMEDIATION_URL)
+            .then((res) => {
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                return res.json();
+            })
+            .then(setMap)
+            .catch(() => setError(true));
+    }, []);
+
+    return { map, error };
+}
+
+function GenericRemediation(): ReactNode {
+    return (
+        <div>
+            <p style={{ margin: 0 }}>
+                No specific remediation found for this rule ID. As general
+                guidance: validate and sanitize any value that originates from
+                the URL, a postMessage, or a server response before it reaches a
+                DOM sink (innerHTML, href, style, eval, etc.), and verify
+                security-relevant checks (authorization, origin validation) are
+                enforced server-side rather than only in the client.
+            </p>
+            <p style={{ marginTop: "0.75rem", marginBottom: 0 }}>
+                See the{" "}
+                <a href="/docs/rules/predefined-rules">
+                    predefined rule catalog
+                </a>{" "}
+                for the full list of rule IDs.
+            </p>
+        </div>
+    );
+}
+
+export default function Remediation(): ReactNode {
+    const { map, error } = useRemediationMap();
+    const [query, setQuery] = useState("");
+
+    const trimmed = query.trim();
+    const match = map && trimmed ? map[trimmed] : undefined;
+
+    return (
+        <Layout
+            title="Remediation"
+            description="Look up remediation guidance for a JS Recon rule ID"
+        >
+            <header className={clsx("hero hero--primary", styles.heroBanner)}>
+                <div className="container">
+                    <Heading as="h1">Rule Remediation Lookup</Heading>
+                    <p className="hero__subtitle">
+                        Enter a rule ID to see how to fix the finding it
+                        detected.
+                    </p>
+                </div>
+            </header>
+            <main style={{ padding: "2rem 0" }}>
+                <div className={clsx("container")} style={{ maxWidth: 720 }}>
+                    <input
+                        type="text"
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        placeholder="e.g. detect_dom_xss_innerHTML_url_source"
+                        aria-label="Rule ID"
+                        style={{
+                            width: "100%",
+                            padding: "0.75rem 1rem",
+                            fontSize: "1rem",
+                            borderRadius: "8px",
+                            border: "1px solid var(--ifm-color-emphasis-300)",
+                            marginBottom: "1.5rem",
+                        }}
+                    />
+
+                    {trimmed && (
+                        <div
+                            style={{
+                                backgroundColor:
+                                    "var(--ifm-background-surface-color-light)",
+                                padding: "1.5rem",
+                                borderRadius: "8px",
+                                boxShadow: "var(--ifm-global-shadow-lw)",
+                            }}
+                        >
+                            <Heading
+                                as="h3"
+                                style={{ marginBottom: "0.75rem" }}
+                            >
+                                {match ? trimmed : "Not found"}
+                            </Heading>
+                            {error ? (
+                                <p style={{ margin: 0 }}>
+                                    Couldn&apos;t load the remediation data
+                                    right now. Please try again shortly.
+                                </p>
+                            ) : !map ? (
+                                <p style={{ margin: 0 }}>Loading…</p>
+                            ) : match ? (
+                                <p style={{ margin: 0 }}>{match}</p>
+                            ) : (
+                                <GenericRemediation />
+                            )}
+                        </div>
+                    )}
+                </div>
+            </main>
+        </Layout>
+    );
+}


### PR DESCRIPTION
## Summary
- Adds a `/remediation` page: enter a rule ID, get concrete fix guidance for the finding it detects. Falls back to generic guidance (with a link to the predefined rule catalog) for unrecognized IDs.
- Fetches `remediation.json` client-side directly from `js-recon-rules`' raw GitHub content endpoint at page load — no backend processing, no build coupling between the two repos. See [js-recon/js-recon-rules#10](https://github.com/js-recon/js-recon-rules/pull/10) for the companion change adding remediation content to all 52 rules.
- Adds a "Remediation" navbar item next to "Labs".
- Adds `@playwright/test` (not previously in this repo) with an e2e spec covering both the known-rule-ID and fallback paths, mocking the raw-content fetch so the suite has no live network dependency.

Ref internal#201

## Test plan
- [x] `npm run test:e2e` — both cases pass
- [x] Manually verified in a real browser: navbar link works, known rule ID shows its remediation, unknown ID shows the fallback with a working link to `/docs/rules/predefined-rules`
- [x] `npx tsc --noEmit` — no new type errors introduced